### PR TITLE
Implement chord duration selection feature #23

### DIFF
--- a/src/components/ChordPalette.css
+++ b/src/components/ChordPalette.css
@@ -5,11 +5,54 @@
   border: 1px solid #444;
 }
 
+.chord-palette-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
 .chord-palette-title {
-  margin: 0 0 1rem 0;
+  margin: 0;
   font-size: 1rem;
   color: #aaa;
   font-weight: 500;
+}
+
+.duration-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.duration-label {
+  font-size: 0.9rem;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.duration-select {
+  padding: 0.4rem 0.6rem;
+  background-color: #333;
+  border: 1px solid #555;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 200px;
+}
+
+.duration-select:hover {
+  border-color: #667eea;
+}
+
+.duration-select:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
 }
 
 .chord-buttons {

--- a/src/components/ChordPalette.tsx
+++ b/src/components/ChordPalette.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Key, Chord } from '../types';
 import { getDiatonicChords, getRomanNumeral, getChordDisplayName } from '../utils/diatonic';
 import { audioEngine } from '../utils/audioEngine';
@@ -8,24 +9,63 @@ interface ChordPaletteProps {
   onChordSelect: (chord: Chord) => void;
 }
 
+type NoteDuration = 4 | 3 | 2 | 1.5 | 1 | 0.75 | 0.5;
+
+const DURATION_OPTIONS: { value: NoteDuration; label: string; symbol: string }[] = [
+  { value: 4, label: 'Whole Note', symbol: '𝅝' },
+  { value: 3, label: 'Dotted Half Note', symbol: '𝅗𝅥.' },
+  { value: 2, label: 'Half Note', symbol: '𝅗𝅥' },
+  { value: 1.5, label: 'Dotted Quarter Note', symbol: '♩.' },
+  { value: 1, label: 'Quarter Note', symbol: '♩' },
+  { value: 0.75, label: 'Dotted Eighth Note', symbol: '♪.' },
+  { value: 0.5, label: 'Eighth Note', symbol: '♪' },
+];
+
 const ChordPalette = ({ selectedKey, onChordSelect }: ChordPaletteProps) => {
   const diatonicChords = getDiatonicChords(selectedKey);
+  const [selectedDuration, setSelectedDuration] = useState<NoteDuration>(4);
 
   const handleChordClick = async (chord: Chord) => {
+    // Create a new chord with the selected duration
+    const chordWithDuration: Chord = {
+      ...chord,
+      duration: selectedDuration,
+    };
+
     try {
       // Play the chord sound
-      await audioEngine.playChord(chord, 2);
+      await audioEngine.playChord(chordWithDuration, 2);
     } catch (error) {
       console.error('Failed to play chord:', error);
       // Continue with adding to progression even if audio fails
     }
     // Add to progression
-    onChordSelect(chord);
+    onChordSelect(chordWithDuration);
   };
 
   return (
     <div className="chord-palette">
-      <h3 className="chord-palette-title">Diatonic Chords</h3>
+      <div className="chord-palette-header">
+        <h3 className="chord-palette-title">Diatonic Chords</h3>
+        <div className="duration-selector">
+          <label htmlFor="duration-select" className="duration-label">
+            Duration:
+          </label>
+          <select
+            id="duration-select"
+            className="duration-select"
+            value={selectedDuration}
+            onChange={(e) => setSelectedDuration(Number(e.target.value) as NoteDuration)}
+            title="Select note duration for added chords"
+          >
+            {DURATION_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.symbol} {option.label} ({option.value} beats)
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
       <div className="chord-buttons">
         {diatonicChords.map((chord, index) => (
           <button

--- a/src/components/ChordSequence.css
+++ b/src/components/ChordSequence.css
@@ -72,6 +72,15 @@
   font-weight: 600;
 }
 
+.chord-item-duration {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  color: #aaa;
+  margin-left: 0.25rem;
+}
+
 .chord-item-remove {
   display: flex;
   align-items: center;

--- a/src/components/ChordSequence.tsx
+++ b/src/components/ChordSequence.tsx
@@ -9,6 +9,28 @@ interface ChordSequenceProps {
   currentIndex?: number;
 }
 
+// Helper function to get note symbol from duration
+const getDurationSymbol = (duration: number): string => {
+  switch (duration) {
+    case 4:
+      return '𝅝'; // Whole note
+    case 3:
+      return '𝅗𝅥.'; // Dotted half note
+    case 2:
+      return '𝅗𝅥'; // Half note
+    case 1.5:
+      return '♩.'; // Dotted quarter note
+    case 1:
+      return '♩'; // Quarter note
+    case 0.75:
+      return '♪.'; // Dotted eighth note
+    case 0.5:
+      return '♪'; // Eighth note
+    default:
+      return `${duration}♩`; // Fallback: show duration + quarter note
+  }
+};
+
 const ChordSequence = ({ chords, onRemoveChord, currentIndex }: ChordSequenceProps) => {
   const handleChordClick = async (chord: Chord) => {
     try {
@@ -44,10 +66,13 @@ const ChordSequence = ({ chords, onRemoveChord, currentIndex }: ChordSequencePro
               className="chord-item-content"
               onClick={() => handleChordClick(chord)}
               style={{ cursor: 'pointer' }}
-              title={`Click to preview ${getChordDisplayName(chord)}`}
+              title={`Click to preview ${getChordDisplayName(chord)} (${chord.duration} beats)`}
             >
               <span className="chord-item-index">{index + 1}</span>
               <span className="chord-item-name">{getChordDisplayName(chord)}</span>
+              <span className="chord-item-duration" title={`${chord.duration} beats`}>
+                {getDurationSymbol(chord.duration)}
+              </span>
             </div>
             <button
               className="chord-item-remove"


### PR DESCRIPTION
## Summary
コード長さ選択機能を実装しました。全音符から8分音符まで、符点音符を含む7種類の音符長さを選択できるようになりました。

## 主な変更内容

### ChordPaletteに音符長さセレクター追加
- **7種類の音符長さを選択可能**:
  - 全音符（4拍）𝅝
  - 付点2分音符（3拍）𝅗𝅥.
  - 2分音符（2拍）𝅗𝅥
  - 付点4分音符（1.5拍）♩.
  - 4分音符（1拍）♩
  - 付点8分音符（0.75拍）♪.
  - 8分音符（0.5拍）♪
- ドロップダウンメニューで直感的に選択
- 音符記号と拍数を表示
- 選択した長さが次回のコード追加まで保持される

### ChordSequenceでの長さ表示
- 各コードの横に音符記号を表示
- ツールチップで拍数を確認可能
- 視覚的に長さが分かりやすい

### 再生機能との統合
- audioEngineは既に可変durationに対応済み
- 進行再生時に選択した長さで正しく再生される
- 異なる長さを混在させたパターンも正常に動作

## 実装詳細

### 型定義
```typescript
type NoteDuration = 4 | 3 | 2 | 1.5 | 1 | 0.75 | 0.5;
```

### コンポーネント変更
- **ChordPalette.tsx**: useStateでduration選択を管理、コード作成時にdurationを適用
- **ChordSequence.tsx**: getDurationSymbol()ヘルパー関数で記号表示
- **ChordPalette.css**: duration selectorのスタイル追加
- **ChordSequence.css**: duration表示のスタイル追加

### 音楽的な意義
- **付点2分音符（3拍）**: ワルツなど3拍子の音楽で使用
- **付点4分音符（1.5拍）**: シャッフルリズム、スウィングで頻出
- **付点8分音符（0.75拍）**: 細かいリズムパターン

## テスト結果

✅ Duration selectorで7種類の音符が選択可能
✅ 選択した長さがChordオブジェクトに正しく反映される
✅ ChordSequenceに音符記号が正しく表示される
✅ 再生時に選択した長さで音が鳴る
✅ 異なる長さを混在させたパターンが正常に動作
✅ 符点音符（3, 1.5, 0.75拍）が正確に再生される
✅ 型チェック: エラーなし

## 次のステップ

この機能は以下の機能の基盤となります:
- #22: 小節ベース表示UI（コード長さに応じた幅の調整）
- #25: コード進行タイムライン表示（durationベースの視覚化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)