### PR TITLE
Implement metronome functionality with time signature support (#20)

### DIFF
--- a/src/components/PlaybackControls.css
+++ b/src/components/PlaybackControls.css
@@ -99,3 +99,55 @@
 .bpm-input[type=number] {
   -moz-appearance: textfield;
 }
+
+.metronome-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #aaa;
+  cursor: pointer;
+  user-select: none;
+}
+
+.metronome-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #667eea;
+}
+
+.time-signature-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #aaa;
+}
+
+.time-signature-select {
+  padding: 0.5rem;
+  background-color: #333;
+  border: 1px solid #555;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 70px;
+}
+
+.time-signature-select:hover:not(:disabled) {
+  border-color: #667eea;
+}
+
+.time-signature-select:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
+}
+
+.time-signature-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/PlaybackControls.tsx
+++ b/src/components/PlaybackControls.tsx
@@ -11,6 +11,8 @@ interface PlaybackControlsProps {
 const PlaybackControls = ({ chords, onPlayingIndexChange }: PlaybackControlsProps) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [bpm, setBpm] = useState(120);
+  const [metronomeEnabled, setMetronomeEnabled] = useState(false);
+  const [timeSignature, setTimeSignature] = useState(4);
 
   const handlePlayProgression = async () => {
     if (chords.length === 0) {
@@ -53,6 +55,18 @@ const PlaybackControls = ({ chords, onPlayingIndexChange }: PlaybackControlsProp
     if (bpm > 240) setBpm(240);
   };
 
+  const handleMetronomeToggle = () => {
+    const newValue = !metronomeEnabled;
+    setMetronomeEnabled(newValue);
+    audioEngine.setMetronomeEnabled(newValue);
+  };
+
+  const handleTimeSignatureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = parseInt(e.target.value, 10);
+    setTimeSignature(value);
+    audioEngine.setTimeSignature(value);
+  };
+
   return (
     <div className="playback-controls">
       <div className="playback-controls-section">
@@ -89,6 +103,43 @@ const PlaybackControls = ({ chords, onPlayingIndexChange }: PlaybackControlsProp
           title={isPlaying ? 'Cannot change BPM during playback' : 'Set playback tempo (40-240 BPM)'}
           aria-label="Beats per minute"
         />
+      </div>
+
+      <div className="playback-controls-section">
+        <label htmlFor="metronome-toggle" className="metronome-label">
+          <input
+            id="metronome-toggle"
+            type="checkbox"
+            className="metronome-checkbox"
+            checked={metronomeEnabled}
+            onChange={handleMetronomeToggle}
+            title="Enable metronome click during playback"
+            aria-label="Metronome toggle"
+          />
+          Metronome
+        </label>
+      </div>
+
+      <div className="playback-controls-section">
+        <label htmlFor="time-signature-select" className="time-signature-label">
+          Time:
+        </label>
+        <select
+          id="time-signature-select"
+          className="time-signature-select"
+          value={timeSignature}
+          onChange={handleTimeSignatureChange}
+          disabled={isPlaying}
+          title={isPlaying ? 'Cannot change time signature during playback' : 'Set time signature'}
+          aria-label="Time signature"
+        >
+          <option value={2}>2/4</option>
+          <option value={3}>3/4</option>
+          <option value={4}>4/4</option>
+          <option value={5}>5/4</option>
+          <option value={6}>6/8</option>
+          <option value={7}>7/8</option>
+        </select>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Added metronome feature to provide audible beat tracking during chord progression playback
- Implemented time signature support (2/4, 3/4, 4/4, 5/4, 6/8, 7/8)
- Added metronome toggle checkbox and time signature selector to PlaybackControls
- Metronome clicks synchronize with BPM and playback state
- Emphasized downbeat (1拍目) with higher pitch (1200 Hz) and volume (-5 dB)
- Regular beats use lower pitch (800 Hz) and volume (-12 dB)

## Changes
- **audioEngine.ts**: 
  - Added MetalSynth for metronome click sound
  - Implemented `setupMetronome()` to create loop synchronized with Transport
  - Added time signature state and setter/getter methods
  - Integrated metronome start/stop with `playProgression()` and `stopProgression()`
  
- **PlaybackControls.tsx**:
  - Added metronome toggle checkbox
  - Added time signature selector dropdown
  - Wired controls to audioEngine methods
  
- **PlaybackControls.css**:
  - Styled metronome checkbox and time signature selector

## Test plan
- [x] Verify metronome click plays at correct BPM
- [x] Verify downbeat (1拍目) has higher pitch and volume
- [x] Verify metronome syncs with chord playback
- [x] Test different time signatures (2/4, 3/4, 4/4, 5/4, 6/8, 7/8)
- [x] Verify metronome can be toggled on/off
- [x] Verify metronome stops when playback stops
- [x] Verify time signature cannot be changed during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)