### PR TITLE
Adjust tonic function marble ratio to show more color2 (#36)

### DIFF
--- a/src/utils/colorGenerator.ts
+++ b/src/utils/colorGenerator.ts
@@ -225,7 +225,7 @@ export function getMarbleRatio(chord: Chord, key: Key): number {
 
   switch (harmonicFunction) {
     case 'tonic':
-      return 0.8; // 80% color1, 20% color2
+      return 0.7; // 70% color1, 30% color2
     case 'subdominant':
       return 0.65; // 65% color1, 35% color2
     case 'dominant':


### PR DESCRIPTION
## Summary

トニック機能のマーブル比率を調整し、色2（コードベース色）の割合を増やしました。

## 変更内容

### マーブル比率の調整

**変更箇所**: `src/utils/colorGenerator.ts:228`

- **変更前**: `0.8` (80% color1, 20% color2)
- **変更後**: `0.7` (70% color1, 30% color2)

### 理由

ユーザーフィードバックにより、トニックコードで色2の割合を増やすことで、色1と色2の絡み合いがより美しく見えることが確認されました。

### 影響範囲

- トニック機能のコード（I, iii, vi）のマーブルパターン
- 具体例（Key=C）: C, Em, Am
- サブドミナント（0.65）とドミナント（0.5）機能は変更なし

## Test plan

- [x] TypeScript型チェック通過
- [x] Key=Cでトニックコード（C, Em, Am）の表示を確認
- [x] マーブルパターンで色2の割合が適切に増加
- [x] ユーザー確認完了（「いい感じです」）

## 関連issue

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)