### PR TITLE
色表示枠の縦幅を短縮（横長化） (#46)

### DIFF
--- a/src/components/VisualizationCanvas.css
+++ b/src/components/VisualizationCanvas.css
@@ -49,7 +49,7 @@
 .visualization-canvas-wrapper {
   position: relative;
   width: 800px;
-  height: 600px;
+  height: 400px;
 }
 
 .visualization-canvas {
@@ -166,12 +166,12 @@
 @media (max-width: 900px) {
   .visualization-canvas-wrapper {
     width: 100%;
-    height: 450px;
+    height: 350px;
   }
 }
 
 @media (max-width: 600px) {
   .visualization-canvas-wrapper {
-    height: 300px;
+    height: 250px;
   }
 }


### PR DESCRIPTION
## 概要

視覚化エリアのアスペクト比を横長に変更し、スクロール削減とタイムライン表示との親和性を向上させました。

Closes #46

## 変更内容

### 視覚化エリアのサイズ変更
- **デスクトップ**: 800x600 → 800x400（アスペクト比 2:1）
- **タブレット**: 450px → 350px（高さ）
- **モバイル**: 300px → 250px（高さ）

### 効果
- ✅ 縦幅を約33%削減（600px → 400px）
- ✅ 横の流れを強調する横長デザイン
- ✅ タイムライン表示との視覚的親和性向上
- ✅ スクロール量の削減

## 技術詳細

### 変更ファイル
- `src/components/VisualizationCanvas.css`

### テスト確認項目
- [x] Single Viewで正しく表示される
- [x] Timeline Viewで正しく表示される
- [x] Playback Modeで正しく表示される
- [x] Preview Modeで正しく表示される
- [x] レスポンシブデザインが機能する

## スクリーンショット

（ユーザー確認済み）

## 関連issue

- #43（画面構成改善）と関連
- #25（タイムライン表示）との親和性向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)