### PR TITLE
Implement hue rotation adjustment UI with interactive color wheel (#13)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,6 +17,7 @@
   flex-direction: column;
   gap: 1.5rem;
   align-items: center;
+  position: relative;
 }
 
 .header h1 {
@@ -58,6 +59,35 @@
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: #fff;
   box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+}
+
+.settings-button {
+  position: absolute;
+  top: 2rem;
+  right: 2rem;
+  width: 48px;
+  height: 48px;
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 50%;
+  color: #aaa;
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-button:hover {
+  background-color: #333;
+  border-color: #667eea;
+  color: #fff;
+  transform: rotate(45deg);
+}
+
+.settings-button:active {
+  transform: rotate(45deg) scale(0.95);
 }
 
 .main {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,13 @@ import { useState, useEffect } from 'react';
 import './App.css';
 import BuildPhase from './components/BuildPhase';
 import ConfirmPhase from './components/ConfirmPhase';
+import SettingsSidebar from './components/SettingsSidebar';
 import { Key, Chord } from './types';
 import { audioEngine } from './utils/audioEngine';
 
 type Phase = 'build' | 'confirm';
+
+const HUE_ROTATION_STORAGE_KEY = 'harmonic-colors-hue-rotation';
 
 function App() {
   const [currentPhase, setCurrentPhase] = useState<Phase>('build');
@@ -20,6 +23,15 @@ function App() {
   const [playbackPosition, setPlaybackPosition] = useState<number>(0); // Current playback position in beats
   const [bpm, setBpm] = useState<number>(120);
   const [metronomeEnabled, setMetronomeEnabled] = useState<boolean>(false);
+
+  // Load hueRotation from LocalStorage
+  const [hueRotation, setHueRotation] = useState<number>(() => {
+    const saved = localStorage.getItem(HUE_ROTATION_STORAGE_KEY);
+    return saved !== null ? Number(saved) : 0;
+  });
+
+  // Settings sidebar state
+  const [isSettingsOpen, setIsSettingsOpen] = useState<boolean>(false);
 
   const handleAddChord = (chord: Chord) => {
     const newProgression = [...chordProgression, chord];
@@ -59,6 +71,11 @@ function App() {
     setPlaybackPosition(position);
   };
 
+  const handleHueRotationChange = (rotation: number) => {
+    setHueRotation(rotation);
+    localStorage.setItem(HUE_ROTATION_STORAGE_KEY, String(rotation));
+  };
+
   // Get current chord for visualization
   // Priority: 1. Playing chord, 2. Selected chord, 3. Last chord
   const currentChord = currentChordIndex >= 0
@@ -94,6 +111,13 @@ function App() {
             確認
           </button>
         </div>
+        <button
+          className="settings-button"
+          onClick={() => setIsSettingsOpen(true)}
+          title="Open settings"
+        >
+          ⚙
+        </button>
       </header>
       <main className="main">
         {currentPhase === 'build' ? (
@@ -112,6 +136,7 @@ function App() {
             onTimeSignatureChange={setTimeSignature}
             onBpmChange={setBpm}
             onMetronomeChange={setMetronomeEnabled}
+            hueRotation={hueRotation}
           />
         ) : (
           <ConfirmPhase
@@ -125,9 +150,19 @@ function App() {
             timeSignature={timeSignature}
             onPlayingIndexChange={handlePlayingIndexChange}
             onPlaybackPositionChange={handlePlaybackPositionChange}
+            hueRotation={hueRotation}
           />
         )}
       </main>
+
+      {/* Settings Sidebar */}
+      <SettingsSidebar
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        hueRotation={hueRotation}
+        onHueRotationChange={handleHueRotationChange}
+        selectedKey={selectedKey}
+      />
     </div>
   )
 }

--- a/src/components/BuildPhase.tsx
+++ b/src/components/BuildPhase.tsx
@@ -24,6 +24,7 @@ interface BuildPhaseProps {
   onTimeSignatureChange: (timeSignature: number) => void;
   onBpmChange: (bpm: number) => void;
   onMetronomeChange: (enabled: boolean) => void;
+  hueRotation: number;
 }
 
 const BuildPhase = ({
@@ -40,7 +41,8 @@ const BuildPhase = ({
   onPlaybackPositionChange,
   onTimeSignatureChange,
   onBpmChange,
-  onMetronomeChange
+  onMetronomeChange,
+  hueRotation
 }: BuildPhaseProps) => {
   // Get current chord for preview
   const currentChord = selectedIndex !== undefined && selectedIndex >= 0
@@ -50,7 +52,7 @@ const BuildPhase = ({
     : undefined;
 
   // Generate colors for info display
-  const color1 = generateKeyColor(selectedKey);
+  const color1 = generateKeyColor(selectedKey, hueRotation);
   const color2 = currentChord ? generateChordColor(currentChord, selectedKey, color1) : color1;
 
   // Get harmonic function info
@@ -59,7 +61,7 @@ const BuildPhase = ({
   return (
     <div className="build-phase">
       <KeySelector selectedKey={selectedKey} onKeyChange={onKeyChange} />
-      <ChordPalette selectedKey={selectedKey} onChordSelect={onChordSelect} />
+      <ChordPalette selectedKey={selectedKey} onChordSelect={onChordSelect} hueRotation={hueRotation} />
       <ChordSequence
         chords={chords}
         onRemoveChord={onRemoveChord}
@@ -76,9 +78,11 @@ const BuildPhase = ({
         onBpmChange={onBpmChange}
         onMetronomeChange={onMetronomeChange}
       />
+
       <VisualizationPreview
         selectedKey={selectedKey}
         currentChord={currentChord}
+        hueRotation={hueRotation}
       />
 
       <div className="visualization-info">

--- a/src/components/ChordColorPreview.tsx
+++ b/src/components/ChordColorPreview.tsx
@@ -5,11 +5,12 @@ import './ChordColorPreview.css';
 interface ChordColorPreviewProps {
   selectedKey: Key;
   chord: Chord;
+  hueRotation?: number;
 }
 
-const ChordColorPreview = ({ selectedKey, chord }: ChordColorPreviewProps) => {
+const ChordColorPreview = ({ selectedKey, chord, hueRotation = 0 }: ChordColorPreviewProps) => {
   // Generate key color (base color)
-  const keyColor = generateKeyColor(selectedKey);
+  const keyColor = generateKeyColor(selectedKey, hueRotation);
 
   // Generate chord color (color 2)
   const chordColor = generateChordColor(chord, selectedKey, keyColor);

--- a/src/components/ChordPalette.tsx
+++ b/src/components/ChordPalette.tsx
@@ -8,6 +8,7 @@ import './ChordPalette.css';
 interface ChordPaletteProps {
   selectedKey: Key;
   onChordSelect: (chord: Chord) => void;
+  hueRotation?: number;
 }
 
 type NoteDuration = 4 | 3 | 2 | 1.5 | 1 | 0.75 | 0.5;
@@ -22,7 +23,7 @@ const DURATION_OPTIONS: { value: NoteDuration; label: string; symbol: string }[]
   { value: 0.5, label: 'Eighth Note', symbol: '♪' },
 ];
 
-const ChordPalette = ({ selectedKey, onChordSelect }: ChordPaletteProps) => {
+const ChordPalette = ({ selectedKey, onChordSelect, hueRotation = 0 }: ChordPaletteProps) => {
   const diatonicChords = getDiatonicChords(selectedKey);
   const [selectedDuration, setSelectedDuration] = useState<NoteDuration>(4);
 
@@ -81,7 +82,7 @@ const ChordPalette = ({ selectedKey, onChordSelect }: ChordPaletteProps) => {
               <div className="chord-button-roman">{getRomanNumeral(selectedKey, index)}</div>
               <div className="chord-button-name">{getChordDisplayName(chord)}</div>
             </button>
-            <ChordColorPreview selectedKey={selectedKey} chord={chord} />
+            <ChordColorPreview selectedKey={selectedKey} chord={chord} hueRotation={hueRotation} />
           </div>
         ))}
       </div>

--- a/src/components/ConfirmPhase.tsx
+++ b/src/components/ConfirmPhase.tsx
@@ -14,6 +14,7 @@ interface ConfirmPhaseProps {
   timeSignature: number;
   onPlayingIndexChange: (index: number) => void;
   onPlaybackPositionChange: (position: number) => void;
+  hueRotation: number;
 }
 
 const ConfirmPhase = ({
@@ -26,7 +27,8 @@ const ConfirmPhase = ({
   metronomeEnabled,
   timeSignature,
   onPlayingIndexChange,
-  onPlaybackPositionChange
+  onPlaybackPositionChange,
+  hueRotation
 }: ConfirmPhaseProps) => {
   return (
     <div className="confirm-phase">
@@ -46,6 +48,7 @@ const ConfirmPhase = ({
         timeSignature={timeSignature}
         onPlayingIndexChange={onPlayingIndexChange}
         onPlaybackPositionChange={onPlaybackPositionChange}
+        hueRotation={hueRotation}
       />
     </div>
   );

--- a/src/components/HueWheel.css
+++ b/src/components/HueWheel.css
@@ -1,0 +1,66 @@
+.hue-wheel-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.hue-wheel-svg {
+  cursor: pointer;
+  user-select: none;
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
+}
+
+.hue-wheel-svg:hover {
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.4));
+}
+
+.hue-wheel-text {
+  user-select: none;
+  pointer-events: none;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+.hue-wheel-key-text {
+  user-select: none;
+  pointer-events: none;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+.hue-wheel-note-marker {
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.hue-wheel-note-marker:hover {
+  filter: drop-shadow(0 2px 6px rgba(255, 255, 255, 0.4));
+}
+
+.hue-wheel-note-label {
+  user-select: none;
+  pointer-events: none;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+
+.hue-wheel-note-label.current {
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.9), 0 0 8px rgba(255, 255, 255, 0.3);
+}
+
+.hue-wheel-marker {
+  cursor: pointer;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+.hue-wheel-labels {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hue-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}

--- a/src/components/HueWheel.tsx
+++ b/src/components/HueWheel.tsx
@@ -1,0 +1,211 @@
+import { Note } from '../types';
+import './HueWheel.css';
+
+interface HueWheelProps {
+  rotation: number;
+  onChange: (rotation: number) => void;
+  currentKey?: Note;
+}
+
+const HueWheel = ({ rotation, onChange, currentKey }: HueWheelProps) => {
+  const size = 260;
+  const center = size / 2;
+  const radius = 90;
+  const markerRadius = 10;
+
+  // 12音のマッピング（C = 0°基準）
+  const NOTES: Note[] = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+  const noteToHue = (note: Note): number => {
+    const index = NOTES.indexOf(note);
+    return index * 30; // 360 / 12 = 30度ずつ
+  };
+
+  // Calculate marker position based on rotation
+  // Rotation is clockwise from top (0° = red at top)
+  const angle = (rotation - 90) * (Math.PI / 180); // -90 to start from top
+  const markerX = center + radius * Math.cos(angle);
+  const markerY = center + radius * Math.sin(angle);
+
+  // Handle click on wheel to set rotation
+  const handleWheelClick = (e: React.MouseEvent<SVGElement>) => {
+    const svg = e.currentTarget;
+    const rect = svg.getBoundingClientRect();
+    const x = e.clientX - rect.left - center;
+    const y = e.clientY - rect.top - center;
+
+    // Calculate angle from center
+    let newAngle = Math.atan2(y, x) * (180 / Math.PI) + 90;
+    if (newAngle < 0) newAngle += 360;
+
+    onChange(Math.round(newAngle % 360));
+  };
+
+  // Generate conic gradient stops for hue wheel
+  const generateGradientStops = () => {
+    const stops = [];
+    const steps = 12; // 12 colors around the wheel
+    for (let i = 0; i <= steps; i++) {
+      const hue = (i * 360) / steps;
+      stops.push(
+        <stop key={i} offset={`${(i * 100) / steps}%`} stopColor={`hsl(${hue}, 100%, 50%)`} />
+      );
+    }
+    return stops;
+  };
+
+  return (
+    <div className="hue-wheel-container">
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        className="hue-wheel-svg"
+        onClick={handleWheelClick}
+      >
+        <defs>
+          {/* Radial gradient for depth effect */}
+          <radialGradient id="hue-radial" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="white" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="black" stopOpacity="0.1" />
+          </radialGradient>
+
+          {/* Conic gradient approximation using multiple segments */}
+          <linearGradient id="hue-gradient-0" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="hsl(0, 100%, 50%)" />
+            <stop offset="100%" stopColor="hsl(30, 100%, 50%)" />
+          </linearGradient>
+        </defs>
+
+        {/* Draw hue wheel as multiple colored segments */}
+        {Array.from({ length: 360 }, (_, i) => {
+          const startAngle = (i - 90) * (Math.PI / 180);
+          const endAngle = (i + 1 - 90) * (Math.PI / 180);
+          const innerRadius = radius - 20;
+
+          const x1 = center + innerRadius * Math.cos(startAngle);
+          const y1 = center + innerRadius * Math.sin(startAngle);
+          const x2 = center + radius * Math.cos(startAngle);
+          const y2 = center + radius * Math.sin(startAngle);
+          const x3 = center + radius * Math.cos(endAngle);
+          const y3 = center + radius * Math.sin(endAngle);
+          const x4 = center + innerRadius * Math.cos(endAngle);
+          const y4 = center + innerRadius * Math.sin(endAngle);
+
+          const path = `M ${x1} ${y1} L ${x2} ${y2} L ${x3} ${y3} L ${x4} ${y4} Z`;
+
+          return (
+            <path
+              key={i}
+              d={path}
+              fill={`hsl(${i}, 100%, 50%)`}
+              stroke="none"
+            />
+          );
+        })}
+
+        {/* Center circle (white background) */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius - 20}
+          fill="#2a2a2a"
+          stroke="#555"
+          strokeWidth="2"
+        />
+
+        {/* Rotation value text in center */}
+        <text
+          x={center}
+          y={center - 10}
+          textAnchor="middle"
+          dominantBaseline="central"
+          className="hue-wheel-text"
+          fill="#fff"
+          fontSize="24"
+          fontWeight="600"
+        >
+          {rotation}°
+        </text>
+
+        {/* Current key label in center */}
+        {currentKey && (
+          <text
+            x={center}
+            y={center + 15}
+            textAnchor="middle"
+            dominantBaseline="central"
+            className="hue-wheel-key-text"
+            fill="#aaa"
+            fontSize="14"
+            fontWeight="500"
+          >
+            Key: {currentKey}
+          </text>
+        )}
+
+        {/* 12音すべてのマーカーを表示 */}
+        {NOTES.map((note) => {
+          const noteHue = noteToHue(note);
+          const actualHue = (noteHue + rotation) % 360;
+          // マーカーの位置も回転を反映
+          const noteAngle = (noteHue + rotation - 90) * (Math.PI / 180);
+          const noteX = center + radius * Math.cos(noteAngle);
+          const noteY = center + radius * Math.sin(noteAngle);
+          const isCurrentKey = note === currentKey;
+
+          return (
+            <g key={note} className="hue-wheel-note-marker">
+              {/* 音名ラベル（外側） */}
+              <text
+                x={noteX + (noteX - center) * 0.35}
+                y={noteY + (noteY - center) * 0.35}
+                textAnchor="middle"
+                dominantBaseline="central"
+                className={`hue-wheel-note-label ${isCurrentKey ? 'current' : ''}`}
+                fill={isCurrentKey ? '#fff' : '#999'}
+                fontSize={isCurrentKey ? '13' : '11'}
+                fontWeight={isCurrentKey ? '700' : '500'}
+              >
+                {note}
+              </text>
+
+              {/* マーカードット */}
+              <circle
+                cx={noteX}
+                cy={noteY}
+                r={isCurrentKey ? markerRadius : 6}
+                fill="white"
+                stroke="#333"
+                strokeWidth={isCurrentKey ? 3 : 2}
+              />
+              <circle
+                cx={noteX}
+                cy={noteY}
+                r={isCurrentKey ? markerRadius - 3 : 4}
+                fill={`hsl(${actualHue}, 100%, 50%)`}
+              />
+            </g>
+          );
+        })}
+
+        {/* Outer ring */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="#555"
+          strokeWidth="2"
+        />
+      </svg>
+
+      <div className="hue-wheel-labels">
+        <div className="hue-label" style={{ color: 'hsl(0, 100%, 60%)' }}>Red (0°)</div>
+        <div className="hue-label" style={{ color: 'hsl(120, 100%, 60%)' }}>Green (120°)</div>
+        <div className="hue-label" style={{ color: 'hsl(240, 100%, 60%)' }}>Blue (240°)</div>
+      </div>
+    </div>
+  );
+};
+
+export default HueWheel;

--- a/src/components/SettingsSidebar.css
+++ b/src/components/SettingsSidebar.css
@@ -1,0 +1,183 @@
+/* Settings Overlay */
+.settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Settings Sidebar */
+.settings-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 320px;
+  background-color: #1e1e1e;
+  border-left: 1px solid #444;
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.settings-sidebar.open {
+  transform: translateX(0);
+}
+
+/* Settings Header */
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 1.5rem 1rem;
+  border-bottom: 1px solid #444;
+}
+
+.settings-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #fff;
+  margin: 0;
+}
+
+.settings-close-button {
+  background: none;
+  border: none;
+  color: #aaa;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.settings-close-button:hover {
+  color: #fff;
+}
+
+/* Settings Content */
+.settings-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+.settings-section {
+  margin-bottom: 2rem;
+}
+
+.settings-section:last-child {
+  margin-bottom: 0;
+}
+
+.settings-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #ddd;
+  margin: 0 0 1rem 0;
+}
+
+.settings-description {
+  font-size: 0.85rem;
+  color: #999;
+  line-height: 1.5;
+  margin: 0.75rem 0 0 0;
+}
+
+/* Hue Rotation Control (in sidebar) */
+.settings-sidebar .hue-rotation-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
+}
+
+.settings-sidebar .hue-rotation-label {
+  font-size: 0.9rem;
+  color: #ccc;
+  font-weight: 500;
+}
+
+.settings-sidebar .hue-rotation-input-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.settings-sidebar .hue-rotation-input {
+  flex: 1;
+  padding: 0.6rem 0.8rem;
+  background-color: #2a2a2a;
+  border: 1px solid #555;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 1rem;
+  transition: all 0.2s;
+}
+
+.settings-sidebar .hue-rotation-input:hover {
+  border-color: #667eea;
+}
+
+.settings-sidebar .hue-rotation-input:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+}
+
+.settings-sidebar .hue-rotation-unit {
+  font-size: 1rem;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.settings-sidebar .hue-rotation-reset {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background-color: #2a2a2a;
+  border: 1px solid #555;
+  border-radius: 6px;
+  color: #ccc;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: 500;
+}
+
+.settings-sidebar .hue-rotation-reset:hover {
+  background-color: #333;
+  border-color: #667eea;
+  color: #fff;
+}
+
+.settings-sidebar .hue-rotation-reset:active {
+  transform: translateY(1px);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .settings-sidebar {
+    width: 100%;
+    max-width: 100%;
+  }
+}

--- a/src/components/SettingsSidebar.tsx
+++ b/src/components/SettingsSidebar.tsx
@@ -1,0 +1,89 @@
+import { Key } from '../types';
+import HueWheel from './HueWheel';
+import './SettingsSidebar.css';
+
+interface SettingsSidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+  hueRotation: number;
+  onHueRotationChange: (rotation: number) => void;
+  selectedKey: Key;
+}
+
+const SettingsSidebar = ({
+  isOpen,
+  onClose,
+  hueRotation,
+  onHueRotationChange,
+  selectedKey
+}: SettingsSidebarProps) => {
+  return (
+    <>
+      {/* Overlay */}
+      {isOpen && (
+        <div className="settings-overlay" onClick={onClose} />
+      )}
+
+      {/* Sidebar */}
+      <div className={`settings-sidebar ${isOpen ? 'open' : ''}`}>
+        <div className="settings-header">
+          <h2 className="settings-title">Settings</h2>
+          <button
+            className="settings-close-button"
+            onClick={onClose}
+            title="Close settings"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="settings-content">
+          {/* Hue Rotation Control */}
+          <div className="settings-section">
+            <h3 className="settings-section-title">Color Adjustment</h3>
+
+            {/* Hue Wheel Visual */}
+            <HueWheel
+              rotation={hueRotation}
+              onChange={onHueRotationChange}
+              currentKey={selectedKey.tonic}
+            />
+
+            <div className="hue-rotation-control">
+              <label htmlFor="hue-rotation" className="hue-rotation-label">
+                Hue Rotation:
+              </label>
+              <div className="hue-rotation-input-group">
+                <input
+                  type="number"
+                  id="hue-rotation"
+                  className="hue-rotation-input"
+                  value={hueRotation}
+                  onChange={(e) => onHueRotationChange(Number(e.target.value))}
+                  min={0}
+                  max={359}
+                  title="Adjust the hue rotation angle (0-359°)"
+                />
+                <span className="hue-rotation-unit">°</span>
+              </div>
+              <button
+                className="hue-rotation-reset"
+                onClick={() => onHueRotationChange(0)}
+                title="Reset to default (0°)"
+              >
+                Reset
+              </button>
+            </div>
+
+            <p className="settings-description">
+              Click on the color wheel or use the input to adjust the hue rotation.
+              This affects all chord colors in the visualization.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SettingsSidebar;

--- a/src/components/TimelineVisualization.tsx
+++ b/src/components/TimelineVisualization.tsx
@@ -16,6 +16,7 @@ interface TimelineVisualizationProps {
   currentIndex: number;
   playbackPosition: number;
   mode: 'playback' | 'preview';
+  hueRotation?: number;
 }
 
 const TimelineVisualization = ({
@@ -23,7 +24,8 @@ const TimelineVisualization = ({
   selectedKey,
   currentIndex,
   playbackPosition,
-  mode
+  mode,
+  hueRotation = 0
 }: TimelineVisualizationProps) => {
   const { camera, gl } = useThree();
   const cameraRef = useRef<OrthographicCamera>(camera as OrthographicCamera);
@@ -37,7 +39,7 @@ const TimelineVisualization = ({
 
   // Generate color data for all chords
   const segmentData = useMemo(() => {
-    const keyColor = generateKeyColor(selectedKey);
+    const keyColor = generateKeyColor(selectedKey, hueRotation);
     let currentX = 0;
 
     return chords.map((chord) => {
@@ -57,7 +59,7 @@ const TimelineVisualization = ({
       currentX += width;
       return segment;
     });
-  }, [chords, selectedKey]);
+  }, [chords, selectedKey, hueRotation]);
 
   // Calculate total width
   const totalWidth = useMemo(() => {

--- a/src/components/VisualizationCanvas.tsx
+++ b/src/components/VisualizationCanvas.tsx
@@ -103,6 +103,7 @@ const VisualizationCanvas = ({
               currentIndex={currentChordIndex}
               playbackPosition={playbackPosition}
               mode={timelineMode}
+              hueRotation={hueRotation}
             />
           </Canvas>
           </div>

--- a/src/components/VisualizationPreview.tsx
+++ b/src/components/VisualizationPreview.tsx
@@ -8,11 +8,12 @@ import './VisualizationPreview.css';
 interface VisualizationPreviewProps {
   selectedKey: Key;
   currentChord?: Chord;
+  hueRotation?: number;
 }
 
-const VisualizationPreview = ({ selectedKey, currentChord }: VisualizationPreviewProps) => {
+const VisualizationPreview = ({ selectedKey, currentChord, hueRotation = 0 }: VisualizationPreviewProps) => {
   // Generate key color (base color)
-  const keyColor = generateKeyColor(selectedKey);
+  const keyColor = generateKeyColor(selectedKey, hueRotation);
 
   // Generate chord color and marble ratio if chord exists
   const chordColor = currentChord ? generateChordColor(currentChord, selectedKey, keyColor) : keyColor;


### PR DESCRIPTION
## Summary
- Implement settings sidebar with hue rotation adjustment UI
- Add interactive color wheel showing all 12 musical notes
- Display real-time marker rotation and color preview
- Add current key highlighting with larger marker
- Support click-to-adjust and number input functionality
- Persist settings to LocalStorage

## Implementation Details

### New Components
- **SettingsSidebar**: Collapsible sidebar accessible via gear icon
- **HueWheel**: Interactive SVG color wheel with 12-note mapping

### Features
- All 12 notes (C, C#, D, ..., B) displayed with color markers
- Markers rotate together when hue rotation changes
- Current key highlighted with larger marker and bold label
- Click anywhere on wheel to set rotation angle
- Number input (0-359°) with reset button
- Settings saved to LocalStorage

### Updated Components
All visualization components now support `hueRotation` parameter:
- ChordColorPreview (chord button colors)
- VisualizationPreview (build phase preview)
- TimelineVisualization (confirmation phase timeline)

### UI/UX Improvements
- Settings button in app header (right-top corner)
- Slide-in animation from right
- Overlay backdrop (click to close)
- Responsive design

## Test plan
- [ ] Open settings sidebar via gear icon
- [ ] Verify color wheel displays all 12 notes correctly
- [ ] Test rotation by clicking on wheel
- [ ] Test rotation by number input
- [ ] Test reset button
- [ ] Change key and verify current key marker updates
- [ ] Verify all visualizations update with hue rotation
- [ ] Refresh page and verify settings persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)