### PR TITLE
テンションノート入力UIをChordEditorモーダルで実装 (#11)

### DIFF
--- a/src/components/ChordEditor.css
+++ b/src/components/ChordEditor.css
@@ -1,0 +1,233 @@
+/* Chord Editor Overlay */
+.chord-editor-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  animation: fadeIn 0.2s ease;
+}
+
+/* Chord Editor Modal */
+.chord-editor {
+  background-color: #1e1e1e;
+  border: 1px solid #444;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Header */
+.chord-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #444;
+}
+
+.chord-editor-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #fff;
+  margin: 0;
+}
+
+.chord-editor-close {
+  background: none;
+  border: none;
+  color: #aaa;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.chord-editor-close:hover {
+  color: #fff;
+}
+
+/* Content */
+.chord-editor-content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Chord Preview */
+.chord-preview {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 8px;
+}
+
+.chord-preview-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.chord-preview-name {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  flex: 1;
+}
+
+/* Editor Section */
+.editor-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #ddd;
+  margin: 0;
+}
+
+/* Button Group */
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.option-button {
+  padding: 0.5rem 1rem;
+  background-color: #2a2a2a;
+  border: 1px solid #555;
+  border-radius: 6px;
+  color: #aaa;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.option-button:hover {
+  background-color: #333;
+  border-color: #667eea;
+  color: #fff;
+}
+
+.option-button.active {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-color: #667eea;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+}
+
+/* Duration Select */
+.duration-select {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #2a2a2a;
+  border: 1px solid #555;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.duration-select:hover {
+  border-color: #667eea;
+}
+
+.duration-select:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+}
+
+/* Footer */
+.chord-editor-footer {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-top: 1px solid #444;
+}
+
+.cancel-button,
+.create-button {
+  flex: 1;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.cancel-button {
+  background-color: #2a2a2a;
+  border: 1px solid #555;
+  color: #aaa;
+}
+
+.cancel-button:hover {
+  background-color: #333;
+  border-color: #666;
+  color: #fff;
+}
+
+.create-button {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border: none;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+}
+
+.create-button:hover {
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.5);
+  transform: translateY(-1px);
+}
+
+.create-button:active {
+  transform: translateY(0);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .chord-editor {
+    width: 95%;
+    max-width: none;
+  }
+
+  .button-group {
+    gap: 0.4rem;
+  }
+
+  .option-button {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
+  }
+}

--- a/src/components/ChordEditor.tsx
+++ b/src/components/ChordEditor.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import { Chord, Note, ChordQuality, SeventhType, Tension, Alteration } from '../types';
+import './ChordEditor.css';
+
+interface ChordEditorProps {
+  root: Note;
+  quality: ChordQuality;
+  onChordCreate: (chord: Chord, duration: number) => void;
+  onCancel: () => void;
+}
+
+type NoteDuration = 4 | 3 | 2 | 1.5 | 1 | 0.75 | 0.5;
+
+const DURATION_OPTIONS: { value: NoteDuration; label: string; symbol: string }[] = [
+  { value: 4, label: 'Whole Note', symbol: '𝅝' },
+  { value: 3, label: 'Dotted Half Note', symbol: '𝅗𝅥.' },
+  { value: 2, label: 'Half Note', symbol: '𝅗𝅥' },
+  { value: 1.5, label: 'Dotted Quarter Note', symbol: '♩.' },
+  { value: 1, label: 'Quarter Note', symbol: '♩' },
+  { value: 0.75, label: 'Dotted Eighth Note', symbol: '♪.' },
+  { value: 0.5, label: 'Eighth Note', symbol: '♪' },
+];
+
+const SEVENTH_OPTIONS: { value: SeventhType | null; label: string }[] = [
+  { value: null, label: 'None' },
+  { value: '7', label: 'Dom7' },
+  { value: 'maj7', label: 'Maj7' },
+  { value: 'm7', label: 'm7' },
+  { value: 'm7b5', label: 'm7♭5' },
+  { value: 'dim7', label: 'dim7' },
+  { value: 'aug7', label: 'aug7' },
+];
+
+const TENSION_OPTIONS: Tension[] = [9, 11, 13];
+const ALTERATION_OPTIONS: Alteration[] = ['b9', '#9', '#11', 'b13'];
+
+const ChordEditor = ({ root, quality, onChordCreate, onCancel }: ChordEditorProps) => {
+  const [seventh, setSeventh] = useState<SeventhType | null>(null);
+  const [tensions, setTensions] = useState<Tension[]>([]);
+  const [alterations, setAlterations] = useState<Alteration[]>([]);
+  const [duration, setDuration] = useState<NoteDuration>(4);
+
+  const toggleTension = (tension: Tension) => {
+    setTensions((prev) =>
+      prev.includes(tension)
+        ? prev.filter((t) => t !== tension)
+        : [...prev, tension].sort()
+    );
+  };
+
+  const toggleAlteration = (alteration: Alteration) => {
+    setAlterations((prev) =>
+      prev.includes(alteration)
+        ? prev.filter((a) => a !== alteration)
+        : [...prev, alteration]
+    );
+  };
+
+  const handleCreate = () => {
+    const chord: Chord = {
+      root,
+      quality,
+      seventh: seventh || undefined,
+      tensions,
+      alterations,
+      duration,
+    };
+    onChordCreate(chord, duration);
+  };
+
+  // Generate chord display name
+  const getChordName = () => {
+    let name = root;
+
+    // Quality
+    if (quality === 'minor') name += 'm';
+    else if (quality === 'diminished') name += 'dim';
+    else if (quality === 'augmented') name += 'aug';
+
+    // Seventh
+    if (seventh) {
+      if (seventh === '7') name += '7';
+      else if (seventh === 'maj7') name += 'maj7';
+      else if (seventh === 'm7') name += 'm7';
+      else if (seventh === 'm7b5') name += 'm7♭5';
+      else if (seventh === 'dim7') name += 'dim7';
+      else if (seventh === 'aug7') name += 'aug7';
+    }
+
+    // Tensions
+    if (tensions.length > 0) {
+      name += '(' + tensions.join(',') + ')';
+    }
+
+    // Alterations
+    if (alterations.length > 0) {
+      name += '(' + alterations.join(',') + ')';
+    }
+
+    return name;
+  };
+
+  return (
+    <div className="chord-editor-overlay" onClick={onCancel}>
+      <div className="chord-editor" onClick={(e) => e.stopPropagation()}>
+        <div className="chord-editor-header">
+          <h3 className="chord-editor-title">Chord Editor</h3>
+          <button className="chord-editor-close" onClick={onCancel} title="Close">
+            ✕
+          </button>
+        </div>
+
+        <div className="chord-editor-content">
+          {/* Chord Preview */}
+          <div className="chord-preview">
+            <div className="chord-preview-label">Chord:</div>
+            <div className="chord-preview-name">{getChordName()}</div>
+          </div>
+
+          {/* Seventh Selection */}
+          <div className="editor-section">
+            <h4 className="section-title">Seventh</h4>
+            <div className="button-group">
+              {SEVENTH_OPTIONS.map((option) => (
+                <button
+                  key={option.label}
+                  className={`option-button ${seventh === option.value ? 'active' : ''}`}
+                  onClick={() => setSeventh(option.value)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Tension Selection */}
+          <div className="editor-section">
+            <h4 className="section-title">Tensions</h4>
+            <div className="button-group">
+              {TENSION_OPTIONS.map((tension) => (
+                <button
+                  key={tension}
+                  className={`option-button ${tensions.includes(tension) ? 'active' : ''}`}
+                  onClick={() => toggleTension(tension)}
+                >
+                  {tension}th
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Alteration Selection */}
+          <div className="editor-section">
+            <h4 className="section-title">Alterations</h4>
+            <div className="button-group">
+              {ALTERATION_OPTIONS.map((alteration) => (
+                <button
+                  key={alteration}
+                  className={`option-button ${alterations.includes(alteration) ? 'active' : ''}`}
+                  onClick={() => toggleAlteration(alteration)}
+                >
+                  {alteration}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Duration Selection */}
+          <div className="editor-section">
+            <h4 className="section-title">Duration</h4>
+            <select
+              className="duration-select"
+              value={duration}
+              onChange={(e) => setDuration(Number(e.target.value) as NoteDuration)}
+            >
+              {DURATION_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.symbol} {option.label} ({option.value} beats)
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="chord-editor-footer">
+          <button className="cancel-button" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="create-button" onClick={handleCreate}>
+            Add Chord
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChordEditor;

--- a/src/components/ChordPalette.css
+++ b/src/components/ChordPalette.css
@@ -67,18 +67,46 @@
   gap: 0;
 }
 
+.chord-button-wrapper {
+  display: flex;
+  gap: 2px;
+}
+
 .chord-button {
   padding: 0.75rem 1rem;
   background: linear-gradient(135deg, #333 0%, #2a2a2a 100%);
   border: 2px solid #555;
-  border-radius: 6px 6px 0 0;
+  border-radius: 6px 0 0 0;
   cursor: pointer;
   transition: all 0.2s;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.25rem;
-  width: 100%;
+  flex: 1;
+}
+
+.edit-chord-button {
+  padding: 0.5rem;
+  background-color: #2a2a2a;
+  border: 2px solid #555;
+  border-radius: 0 6px 0 0;
+  border-left: none;
+  color: #aaa;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+}
+
+.edit-chord-button:hover {
+  background-color: #3a3a3a;
+  border-color: #667eea;
+  color: #fff;
+  transform: scale(1.05);
 }
 
 .chord-button:hover {

--- a/src/utils/diatonic.ts
+++ b/src/utils/diatonic.ts
@@ -83,24 +83,31 @@ export function getChordDisplayName(chord: Chord): string {
 
   // Add seventh
   if (seventh) {
-    if (seventh === 'maj7') {
+    if (seventh === '7') {
+      name += '7';
+    } else if (seventh === 'maj7') {
       name += 'maj7';
     } else if (seventh === 'm7') {
-      name += '7'; // For minor chords, m7 is common notation
-    } else {
-      name += seventh;
+      // For minor seventh, just add 7 (Cm7 is standard notation)
+      name += '7';
+    } else if (seventh === 'm7b5') {
+      name += 'm7♭5';
+    } else if (seventh === 'dim7') {
+      name += 'dim7';
+    } else if (seventh === 'aug7') {
+      name += 'aug7';
     }
   }
 
-  // Add tensions
-  tensions.forEach(tension => {
-    name += `(${tension})`;
-  });
+  // Add tensions (in parentheses if present)
+  if (tensions.length > 0) {
+    name += '(' + tensions.join(',') + ')';
+  }
 
-  // Add alterations
-  alterations.forEach(alt => {
-    name += `(${alt})`;
-  });
+  // Add alterations (in parentheses if present)
+  if (alterations.length > 0) {
+    name += '(' + alterations.join(',') + ')';
+  }
 
   return name;
 }


### PR DESCRIPTION
## 概要
セブンス、テンション、オルタレーションを含む複雑なコードを作成できる、包括的なコード編集システムをモーダルベースのUIで実装しました。

## 主な機能
- **ChordEditorモーダルコンポーネント**: コード編集用のフル機能モーダルダイアログ
  - セブンス選択（7, maj7, m7, m7♭5, dim7, aug7）
  - テンション選択（9th, 11th, 13th）- 複数選択可能
  - オルタレーション選択（♭9, ♯9, ♯11, ♭13）- 複数選択可能
  - 音符記号付きの長さ選択
  - 現在のコード名を表示するリアルタイムプレビュー
  - コード追加時の音声再生

- **ChordPaletteへの統合**: 
  - 各ダイアトニックコードボタンの横に編集ボタン（✏️）を追加
  - 編集ボタンに対応するため、コードボタンのレイアウトを分割
  - 編集ボタンクリックでモーダルが開く
  - 既存のコード選択ワークフローとシームレスに統合

- **コード表示の改善**:
  - `diatonic.ts`の`getChordDisplayName()`を更新
  - 正しいセブンス表記（Cmm7ではなくCm7）
  - テンションをグループ化して表示: `(9,11,13)`
  - オルタレーションをグループ化して表示: `(♭9,♯9,♯11,♭13)`
  - 例: `C7(9,13)`, `Cm7♭5(♭9)`, `Cmaj7(9,11,13)(♯11)`

## 音声エンジンの改善
- **セブンスコードの正確な音生成**:
  - セブンスタイプが3度と5度の音程を正しく決定するように修正
  - m7、m7♭5、dim7、aug7の各コードで正しい構成音を生成
  
- **オルタレーションの音生成実装**:
  - ♭9（ルート+13半音）、♯9（ルート+15半音）
  - ♯11（ルート+18半音）、♭13（ルート+20半音）
  - オルタレーションが選択されたときに正しい音が鳴るように実装

- **音割れ対策**:
  - コンプレッサー（threshold: -24dB, ratio: 4:1）を追加
  - リミッター（-1dB）でピークリミット
  - シンセサイザーの音量を-8dBに調整
  - エンベロープの最適化（sustain: 0.5, release: 1.2）
  - 複雑なコードや高音域でもクリアな音質を実現

## 変更されたファイル
- `src/components/ChordEditor.tsx`（新規）: テンション/オルタレーションUI付きモーダルコンポーネント
- `src/components/ChordEditor.css`（新規）: アニメーション付き完全なスタイリング
- `src/components/ChordPalette.tsx`: 編集ボタンとChordEditorの統合
- `src/components/ChordPalette.css`: 分割ボタンデザイン用のレイアウト更新
- `src/utils/diatonic.ts`: 複雑なコード用に`getChordDisplayName()`を改善
- `src/utils/audioEngine.ts`: セブンスコード/オルタレーションの音生成、音割れ対策を実装

## テストプラン
- [ ] 任意のダイアトニックコードの編集ボタン（✏️）をクリックしてChordEditorを開く
- [ ] 基本コードを表示したコードプレビューでモーダルが開くことを確認
- [ ] 異なるセブンスタイプを選択してプレビューが更新されることを確認
- [ ] 複数のテンション（9th, 11th, 13th）を切り替えてプレビューに表示されることを確認
- [ ] 複数のオルタレーション（♭9, ♯9, ♯11, ♭13）を切り替えてプレビューに表示されることを確認
- [ ] 長さを変更してコードに含まれることを確認
- [ ] 「Add Chord」をクリックして以下を確認:
  - 正しい表記でコード進行に追加される
  - 正しいコードの音が再生される
  - モーダルが閉じる
- [ ] 「Cancel」またはモーダル外をクリックして、コードを追加せずにモーダルが閉じることを確認
- [ ] ChordSequenceでコード表記が正しく表示されることを確認
- [ ] 小さい画面でのレスポンシブ動作をテスト
- [ ] セブンスコード（m7, m7♭5, dim7, aug7）の音が正しいことを確認
- [ ] オルタレーション付きコードの音が正しいことを確認
- [ ] 複雑なコード（例: C7(9,11,13)(♭9,♯11)）で音割れが発生しないことを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)