### PR TITLE
組み立てフェーズでコード情報を直接編集できる機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,18 @@ function App() {
     setSelectedChordIndex(index);
   };
 
+  const handleUpdateChord = (index: number, updatedChord: Chord) => {
+    setSections(sections.map(section => {
+      if (section.id === currentSectionId) {
+        return {
+          ...section,
+          chords: section.chords.map((chord, i) => i === index ? updatedChord : chord)
+        };
+      }
+      return section;
+    }));
+  };
+
   const handleKeyChange = (newKey: Key) => {
     setSections(sections.map(section => {
       if (section.id === currentSectionId) {
@@ -215,6 +227,7 @@ function App() {
             onChordSelect={handleAddChord}
             onRemoveChord={handleRemoveChord}
             onSelectChord={handleSelectChord}
+            onUpdateChord={handleUpdateChord}
             currentIndex={currentChordIndex >= 0 ? currentChordIndex : undefined}
             selectedIndex={selectedChordIndex !== null ? selectedChordIndex : undefined}
             timeSignature={timeSignature}

--- a/src/components/BuildPhase.tsx
+++ b/src/components/BuildPhase.tsx
@@ -3,6 +3,7 @@ import ChordPalette from './ChordPalette';
 import ChordSequence from './ChordSequence';
 import PlaybackControls from './PlaybackControls';
 import VisualizationPreview from './VisualizationPreview';
+import EditableChordInfo from './EditableChordInfo';
 import { generateKeyColor, generateChordColor, hslToCSS } from '../utils/colorGenerator';
 import { getChordDisplayName } from '../utils/diatonic';
 import { analyzeHarmonicFunction } from '../utils/harmonicAnalysis';
@@ -15,6 +16,7 @@ interface BuildPhaseProps {
   onChordSelect: (chord: Chord) => void;
   onRemoveChord: (index: number) => void;
   onSelectChord: (index: number) => void;
+  onUpdateChord: (index: number, chord: Chord) => void;
   currentIndex?: number;
   selectedIndex?: number;
   timeSignature: number;
@@ -41,6 +43,7 @@ const BuildPhase = ({
   onChordSelect,
   onRemoveChord,
   onSelectChord,
+  onUpdateChord,
   currentIndex,
   selectedIndex,
   timeSignature,
@@ -159,6 +162,15 @@ const BuildPhase = ({
           </div>
         )}
       </div>
+
+      {/* Editable chord info when a chord is selected */}
+      {selectedIndex !== undefined && selectedIndex >= 0 && currentChord && (
+        <EditableChordInfo
+          chord={currentChord}
+          chordIndex={selectedIndex}
+          onUpdate={onUpdateChord}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/EditableChordInfo.css
+++ b/src/components/EditableChordInfo.css
@@ -1,0 +1,83 @@
+.editable-chord-info {
+  background-color: #1e1e1e;
+  border: 2px solid #667eea;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.edit-section-title {
+  margin: 0 0 1rem 0;
+  font-size: 1.1rem;
+  color: #667eea;
+  font-weight: 600;
+}
+
+.edit-section {
+  margin-bottom: 1rem;
+}
+
+.edit-section:last-child {
+  margin-bottom: 0;
+}
+
+.edit-label {
+  display: block;
+  font-size: 0.9rem;
+  color: #aaa;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+.edit-button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.edit-button {
+  padding: 0.4rem 0.8rem;
+  background-color: #2a2a2a;
+  border: 2px solid #444;
+  border-radius: 6px;
+  color: #ccc;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 40px;
+}
+
+.edit-button:hover {
+  background-color: #333;
+  border-color: #667eea;
+}
+
+.edit-button.active {
+  background-color: #667eea;
+  border-color: #667eea;
+  color: #fff;
+  font-weight: 600;
+}
+
+.edit-duration-select {
+  width: 100%;
+  padding: 0.5rem;
+  background-color: #2a2a2a;
+  border: 2px solid #444;
+  border-radius: 6px;
+  color: #ccc;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.edit-duration-select:hover {
+  border-color: #667eea;
+}
+
+.edit-duration-select:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+}

--- a/src/components/EditableChordInfo.tsx
+++ b/src/components/EditableChordInfo.tsx
@@ -1,0 +1,230 @@
+import { useState, useEffect } from 'react';
+import { Chord, Note, ChordQuality, SeventhType, Tension, Alteration } from '../types';
+import './EditableChordInfo.css';
+
+interface EditableChordInfoProps {
+  chord: Chord;
+  chordIndex: number;
+  onUpdate: (index: number, chord: Chord) => void;
+}
+
+type NoteDuration = 4 | 3 | 2 | 1.5 | 1 | 0.75 | 0.5;
+
+const DURATION_OPTIONS: { value: NoteDuration; label: string; symbol: string }[] = [
+  { value: 4, label: 'Whole Note', symbol: '𝅝' },
+  { value: 3, label: 'Dotted Half Note', symbol: '𝅗𝅥.' },
+  { value: 2, label: 'Half Note', symbol: '𝅗𝅥' },
+  { value: 1.5, label: 'Dotted Quarter Note', symbol: '♩.' },
+  { value: 1, label: 'Quarter Note', symbol: '♩' },
+  { value: 0.75, label: 'Dotted Eighth Note', symbol: '♪.' },
+  { value: 0.5, label: 'Eighth Note', symbol: '♪' },
+];
+
+const SEVENTH_OPTIONS_BY_QUALITY: Record<ChordQuality, { value: SeventhType | null; label: string }[]> = {
+  major: [
+    { value: null, label: 'None' },
+    { value: '7', label: 'Dom7' },
+    { value: 'maj7', label: 'Maj7' },
+  ],
+  minor: [
+    { value: null, label: 'None' },
+    { value: 'm7', label: 'm7' },
+    { value: 'mMaj7', label: 'mMaj7' },
+  ],
+  diminished: [
+    { value: null, label: 'None' },
+    { value: 'm7b5', label: 'm7♭5' },
+    { value: 'dim7', label: 'dim7' },
+  ],
+  augmented: [
+    { value: null, label: 'None' },
+    { value: 'aug7', label: 'aug7' },
+    { value: 'augMaj7', label: 'augMaj7' },
+  ],
+};
+
+const TENSION_OPTIONS: Tension[] = [9, 11, 13];
+const ALTERATION_OPTIONS: Alteration[] = ['b9', '#9', '#11', 'b13'];
+
+const ALL_NOTES: Note[] = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const ALL_QUALITIES: ChordQuality[] = ['major', 'minor', 'diminished', 'augmented'];
+
+const EditableChordInfo = ({ chord, chordIndex, onUpdate }: EditableChordInfoProps) => {
+  const [root, setRoot] = useState<Note>(chord.root);
+  const [quality, setQuality] = useState<ChordQuality>(chord.quality);
+  const [seventh, setSeventh] = useState<SeventhType | null>(chord.seventh || null);
+  const [tensions, setTensions] = useState<Tension[]>(chord.tensions || []);
+  const [alterations, setAlterations] = useState<Alteration[]>(chord.alterations || []);
+  const [duration, setDuration] = useState<NoteDuration>(chord.duration as NoteDuration);
+
+  // Update local state when chord prop changes
+  useEffect(() => {
+    setRoot(chord.root);
+    setQuality(chord.quality);
+    setSeventh(chord.seventh || null);
+    setTensions(chord.tensions || []);
+    setAlterations(chord.alterations || []);
+    setDuration(chord.duration as NoteDuration);
+  }, [chord]);
+
+  // Get available seventh options based on current quality
+  const availableSeventhOptions = SEVENTH_OPTIONS_BY_QUALITY[quality];
+
+  const handleRootChange = (newRoot: Note) => {
+    setRoot(newRoot);
+    updateChord({ ...chord, root: newRoot });
+  };
+
+  const handleQualityChange = (newQuality: ChordQuality) => {
+    setQuality(newQuality);
+    const newAvailableOptions = SEVENTH_OPTIONS_BY_QUALITY[newQuality];
+    const isSeventhAvailable = newAvailableOptions.some(opt => opt.value === seventh);
+
+    const updatedChord: Chord = {
+      ...chord,
+      quality: newQuality,
+      seventh: isSeventhAvailable ? (seventh || undefined) : undefined
+    };
+
+    if (!isSeventhAvailable) {
+      setSeventh(null);
+    }
+
+    updateChord(updatedChord);
+  };
+
+  const handleSeventhChange = (newSeventh: SeventhType | null) => {
+    setSeventh(newSeventh);
+    updateChord({ ...chord, seventh: newSeventh || undefined });
+  };
+
+  const toggleTension = (tension: Tension) => {
+    const newTensions = tensions.includes(tension)
+      ? tensions.filter((t) => t !== tension)
+      : [...tensions, tension].sort();
+    setTensions(newTensions);
+    updateChord({ ...chord, tensions: newTensions });
+  };
+
+  const toggleAlteration = (alteration: Alteration) => {
+    const newAlterations = alterations.includes(alteration)
+      ? alterations.filter((a) => a !== alteration)
+      : [...alterations, alteration];
+    setAlterations(newAlterations);
+    updateChord({ ...chord, alterations: newAlterations });
+  };
+
+  const handleDurationChange = (newDuration: NoteDuration) => {
+    setDuration(newDuration);
+    updateChord({ ...chord, duration: newDuration });
+  };
+
+  const updateChord = (updatedChord: Chord) => {
+    onUpdate(chordIndex, updatedChord);
+  };
+
+  return (
+    <div className="editable-chord-info">
+      <h4 className="edit-section-title">Edit Chord</h4>
+
+      {/* Root Selection */}
+      <div className="edit-section">
+        <label className="edit-label">Root:</label>
+        <div className="edit-button-group">
+          {ALL_NOTES.map((note) => (
+            <button
+              key={note}
+              className={`edit-button ${root === note ? 'active' : ''}`}
+              onClick={() => handleRootChange(note)}
+              title={note}
+            >
+              {note}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Quality Selection */}
+      <div className="edit-section">
+        <label className="edit-label">Quality:</label>
+        <div className="edit-button-group">
+          {ALL_QUALITIES.map((q) => (
+            <button
+              key={q}
+              className={`edit-button ${quality === q ? 'active' : ''}`}
+              onClick={() => handleQualityChange(q)}
+            >
+              {q === 'major' ? 'Major' : q === 'minor' ? 'Minor' : q === 'diminished' ? 'Dim' : 'Aug'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Seventh Selection */}
+      <div className="edit-section">
+        <label className="edit-label">Seventh:</label>
+        <div className="edit-button-group">
+          {availableSeventhOptions.map((option) => (
+            <button
+              key={option.label}
+              className={`edit-button ${seventh === option.value ? 'active' : ''}`}
+              onClick={() => handleSeventhChange(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tension Selection */}
+      <div className="edit-section">
+        <label className="edit-label">Tensions:</label>
+        <div className="edit-button-group">
+          {TENSION_OPTIONS.map((tension) => (
+            <button
+              key={tension}
+              className={`edit-button ${tensions.includes(tension) ? 'active' : ''}`}
+              onClick={() => toggleTension(tension)}
+            >
+              {tension}th
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Alteration Selection */}
+      <div className="edit-section">
+        <label className="edit-label">Alterations:</label>
+        <div className="edit-button-group">
+          {ALTERATION_OPTIONS.map((alteration) => (
+            <button
+              key={alteration}
+              className={`edit-button ${alterations.includes(alteration) ? 'active' : ''}`}
+              onClick={() => toggleAlteration(alteration)}
+            >
+              {alteration}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Duration Selection */}
+      <div className="edit-section">
+        <label className="edit-label">Duration:</label>
+        <select
+          className="edit-duration-select"
+          value={duration}
+          onChange={(e) => handleDurationChange(Number(e.target.value) as NoteDuration)}
+        >
+          {DURATION_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.symbol} {option.label} ({option.value} beats)
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default EditableChordInfo;


### PR DESCRIPTION
## 概要

コードを選択した際に、Visualization Preview下部に編集UIを表示し、削除→再追加することなく効率的にコードを修正できるようになりました。

## 主な変更内容

### 新規コンポーネント
- **EditableChordInfo**: コード編集UI
  - Root、Quality、Seventh、Tensions、Alterations、Durationの全項目を編集可能
  - リアルタイム更新により、変更が即座に反映
  - ChordEditorと統一されたUIデザイン

### App.tsx
- `handleUpdateChord`ハンドラーを追加
  - 現在のセクション内の指定インデックスのコードを更新
  - BuildPhaseに`onUpdateChord`プロップとして渡す

### BuildPhase.tsx
- `onUpdateChord`プロップを追加
- `selectedIndex`が設定されている時にEditableChordInfoを表示
- EditableChordInfoコンポーネントをインポート

## ユーザーメリット

- **ワークフローの改善**: 削除→再追加の手間がなくなり、直感的な編集が可能
- **効率的な修正**: ChordSequenceでコードをクリックするだけで編集モードに
- **視覚的フィードバック**: 変更が即座にVisualization Previewに反映され、確認しながら調整可能
- **完全な編集機能**: コードの全属性を1箇所で編集可能

## 使用方法

1. ChordSequenceでコードをクリックして選択
2. Visualization Preview下部にEditableChordInfoが表示される
3. Root、Quality、Seventh、Tensions、Alterations、Durationを編集
4. 変更が即座にコード進行とビジュアライゼーションに反映

## スクリーンショット

（必要に応じて追加してください）

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)