### PR TITLE
確認フェーズで各コードを所属セクションのキーに基づいて色付けする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,9 @@ function App() {
   const handleAddChord = (chord: Chord) => {
     setSections(sections.map(section => {
       if (section.id === currentSectionId) {
-        const newChords = [...section.chords, chord];
+        // Add sectionId to the chord
+        const chordWithSection = { ...chord, sectionId: section.id };
+        const newChords = [...section.chords, chordWithSection];
         // Auto-select the newly added chord
         setSelectedChordIndex(newChords.length - 1);
         return { ...section, chords: newChords };
@@ -109,7 +111,9 @@ function App() {
       if (section.id === currentSectionId) {
         return {
           ...section,
-          chords: section.chords.map((chord, i) => i === index ? updatedChord : chord)
+          chords: section.chords.map((chord, i) =>
+            i === index ? { ...updatedChord, sectionId: section.id } : chord
+          )
         };
       }
       return section;
@@ -251,6 +255,7 @@ function App() {
             currentChord={currentChord}
             chordProgression={chordProgression}
             allChords={allChords}
+            sections={sections}
             currentChordIndex={currentChordIndex}
             playbackPosition={playbackPosition}
             bpm={bpm}

--- a/src/components/ConfirmPhase.tsx
+++ b/src/components/ConfirmPhase.tsx
@@ -1,4 +1,4 @@
-import { Key, Chord } from '../types';
+import { Key, Chord, Section } from '../types';
 import VisualizationCanvas from './VisualizationCanvas';
 import ChordNameBar from './ChordNameBar';
 import './ConfirmPhase.css';
@@ -8,6 +8,7 @@ interface ConfirmPhaseProps {
   currentChord?: Chord;
   chordProgression: Chord[];
   allChords: Chord[]; // All chords from all sections for playback
+  sections: Section[]; // All sections for key lookup
   currentChordIndex: number;
   playbackPosition: number;
   bpm: number;
@@ -23,6 +24,7 @@ const ConfirmPhase = ({
   currentChord,
   chordProgression,
   allChords,
+  sections,
   currentChordIndex,
   playbackPosition,
   bpm,
@@ -43,6 +45,7 @@ const ConfirmPhase = ({
         selectedKey={selectedKey}
         currentChord={currentChord}
         chordProgression={allChords}
+        sections={sections}
         currentChordIndex={currentChordIndex}
         playbackPosition={playbackPosition}
         bpm={bpm}

--- a/src/components/VisualizationCanvas.tsx
+++ b/src/components/VisualizationCanvas.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { Chord, Key } from '../types';
+import { Chord, Key, Section } from '../types';
 import TimelineVisualization from './TimelineVisualization';
 import CompactPlayButton from './CompactPlayButton';
 import './VisualizationCanvas.css';
@@ -10,6 +10,7 @@ interface VisualizationCanvasProps {
   currentChord?: Chord;
   hueRotation?: number;
   chordProgression?: Chord[];
+  sections?: Section[]; // All sections for key lookup
   currentChordIndex?: number;
   playbackPosition?: number;
   bpm?: number;
@@ -23,6 +24,7 @@ const VisualizationCanvas = ({
   selectedKey,
   hueRotation = 0,
   chordProgression = [],
+  sections = [],
   currentChordIndex = -1,
   playbackPosition = 0,
   bpm = 120,
@@ -99,6 +101,7 @@ const VisualizationCanvas = ({
             <TimelineVisualization
               chords={chordProgression}
               selectedKey={selectedKey}
+              sections={sections}
               currentIndex={currentChordIndex}
               playbackPosition={playbackPosition}
               mode={timelineMode}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface Chord {
   tensions: Tension[];
   alterations: Alteration[];
   duration: number; // in beats
+  sectionId?: string; // ID of the section this chord belongs to (for multi-section progressions)
 }
 
 export interface Key {


### PR DESCRIPTION
## 概要

複数セクションが存在する場合、確認フェーズで全てのコードが現在選択中のセクションのキーで色計算されていた問題を修正しました。各コードが所属するセクションのキーを使用して色付けされるようになり、転調が視覚的に明確になります。

## 問題

### 修正前の動作
- Section 1 (C Major): C, F, G → キーC Majorで色計算（正しい）
- Section 2 (F Major): F, Bb, C → **キーC Majorで色計算（間違い）**

確認フェーズでは`selectedKey`（現在選択中のセクションのキー）を全コードに使用していたため、セクション2以降のコードが誤ったキーで色計算されていました。

## 解決方法

### 実装内容

1. **Chord型に`sectionId`を追加**
   - 各コードが所属するセクションを識別可能に

2. **コード作成時に`sectionId`を設定**
   - `handleAddChord`: 新規コード追加時
   - `handleUpdateChord`: コード編集時

3. **セクション情報をConfirmPhaseに渡す**
   - App.tsx → ConfirmPhase → VisualizationCanvas → TimelineVisualization

4. **TimelineVisualizationで各コードのセクションキーを使用**
   - `chord.sectionId`から該当セクションを検索
   - そのセクションのキーで色生成

### 修正後の動作
- Section 1 (C Major): C, F, G → キーC Majorで色計算（正しい）
- Section 2 (F Major): F, Bb, C → **キーF Majorで色計算（正しい）**

## 技術的詳細

### ファイル変更
- `src/types/index.ts`: Chord型に`sectionId?: string`を追加
- `src/App.tsx`: コード作成/更新時に`sectionId`を設定、ConfirmPhaseに`sections`を渡す
- `src/components/ConfirmPhase.tsx`: `sections`を受け取りVisualizationCanvasに渡す
- `src/components/VisualizationCanvas.tsx`: `sections`を受け取りTimelineVisualizationに渡す
- `src/components/TimelineVisualization.tsx`: 各コードのセクションキーで色生成

### 色生成ロジック
```typescript
// 各コードのセクションキーを取得
const chordKey = chord.sectionId && sections.length > 0
  ? sections.find(s => s.id === chord.sectionId)?.key || selectedKey
  : selectedKey;

// セクションキーで色生成
const keyColor = generateKeyColor(chordKey, hueRotation);
const chordColor = generateChordColor(chord, chordKey, keyColor);
const marbleRatio = getMarbleRatio(chord, chordKey);
```

## 効果

転調が視覚的に劇的な色相変化として表現されるようになり、複数キーを持つコード進行の構造が一目で理解できます。

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)