### PR TITLE
マイナースケールタイプ選択機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,13 @@ import './App.css';
 import BuildPhase from './components/BuildPhase';
 import ConfirmPhase from './components/ConfirmPhase';
 import SettingsSidebar from './components/SettingsSidebar';
-import { Key, Chord, Section } from './types';
+import { Key, Chord, Section, MinorScaleType } from './types';
 import { audioEngine } from './utils/audioEngine';
 
 type Phase = 'build' | 'confirm';
 
 const HUE_ROTATION_STORAGE_KEY = 'harmonic-colors-hue-rotation';
+const MINOR_SCALE_TYPE_STORAGE_KEY = 'harmonic-colors-minor-scale-type';
 
 function App() {
   const [currentPhase, setCurrentPhase] = useState<Phase>('build');
@@ -41,6 +42,12 @@ function App() {
   const [hueRotation, setHueRotation] = useState<number>(() => {
     const saved = localStorage.getItem(HUE_ROTATION_STORAGE_KEY);
     return saved !== null ? Number(saved) : 0;
+  });
+
+  // Load minorScaleType from LocalStorage (default: melodic)
+  const [minorScaleType, setMinorScaleType] = useState<MinorScaleType>(() => {
+    const saved = localStorage.getItem(MINOR_SCALE_TYPE_STORAGE_KEY);
+    return (saved as MinorScaleType) || 'melodic';
   });
 
   // Settings sidebar state
@@ -134,6 +141,11 @@ function App() {
   const handleHueRotationChange = (rotation: number) => {
     setHueRotation(rotation);
     localStorage.setItem(HUE_ROTATION_STORAGE_KEY, String(rotation));
+  };
+
+  const handleMinorScaleTypeChange = (scaleType: MinorScaleType) => {
+    setMinorScaleType(scaleType);
+    localStorage.setItem(MINOR_SCALE_TYPE_STORAGE_KEY, scaleType);
   };
 
   // Section management handlers
@@ -232,6 +244,7 @@ function App() {
             onBpmChange={setBpm}
             onMetronomeChange={setMetronomeEnabled}
             hueRotation={hueRotation}
+            minorScaleType={minorScaleType}
             sections={sections}
             currentSectionId={currentSectionId}
             onSectionSelect={setCurrentSectionId}
@@ -266,6 +279,8 @@ function App() {
         hueRotation={hueRotation}
         onHueRotationChange={handleHueRotationChange}
         selectedKey={selectedKey}
+        minorScaleType={minorScaleType}
+        onMinorScaleTypeChange={handleMinorScaleTypeChange}
       />
     </div>
   )

--- a/src/components/BuildPhase.tsx
+++ b/src/components/BuildPhase.tsx
@@ -1,4 +1,4 @@
-import { Key, Chord, Section } from '../types';
+import { Key, Chord, Section, MinorScaleType } from '../types';
 import ChordPalette from './ChordPalette';
 import ChordSequence from './ChordSequence';
 import PlaybackControls from './PlaybackControls';
@@ -26,6 +26,7 @@ interface BuildPhaseProps {
   onBpmChange: (bpm: number) => void;
   onMetronomeChange: (enabled: boolean) => void;
   hueRotation: number;
+  minorScaleType: MinorScaleType;
   // Section management
   sections: Section[];
   currentSectionId: string;
@@ -53,6 +54,7 @@ const BuildPhase = ({
   onBpmChange,
   onMetronomeChange,
   hueRotation,
+  minorScaleType,
   sections,
   currentSectionId,
   onSectionSelect,
@@ -77,7 +79,7 @@ const BuildPhase = ({
 
   return (
     <div className="build-phase">
-      <ChordPalette selectedKey={selectedKey} onChordSelect={onChordSelect} hueRotation={hueRotation} />
+      <ChordPalette selectedKey={selectedKey} onChordSelect={onChordSelect} hueRotation={hueRotation} minorScaleType={minorScaleType} />
       <ChordSequence
         sections={sections}
         currentSectionId={currentSectionId}

--- a/src/components/ChordPalette.tsx
+++ b/src/components/ChordPalette.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Key, Chord } from '../types';
+import { Key, Chord, MinorScaleType } from '../types';
 import { getDiatonicChords, getRomanNumeral, getChordDisplayName } from '../utils/diatonic';
 import { audioEngine } from '../utils/audioEngine';
 import ChordColorPreview from './ChordColorPreview';
@@ -10,6 +10,7 @@ interface ChordPaletteProps {
   selectedKey: Key;
   onChordSelect: (chord: Chord) => void;
   hueRotation?: number;
+  minorScaleType: MinorScaleType;
 }
 
 type NoteDuration = 4 | 3 | 2 | 1.5 | 1 | 0.75 | 0.5;
@@ -24,8 +25,8 @@ const DURATION_OPTIONS: { value: NoteDuration; label: string; symbol: string }[]
   { value: 0.5, label: 'Eighth Note', symbol: '♪' },
 ];
 
-const ChordPalette = ({ selectedKey, onChordSelect, hueRotation = 0 }: ChordPaletteProps) => {
-  const diatonicChords = getDiatonicChords(selectedKey);
+const ChordPalette = ({ selectedKey, onChordSelect, hueRotation = 0, minorScaleType }: ChordPaletteProps) => {
+  const diatonicChords = getDiatonicChords(selectedKey, minorScaleType);
   const [selectedDuration, setSelectedDuration] = useState<NoteDuration>(4);
   const [editingChord, setEditingChord] = useState<Chord | null>(null);
   const [isCreatingNew, setIsCreatingNew] = useState<boolean>(false);
@@ -122,9 +123,9 @@ const ChordPalette = ({ selectedKey, onChordSelect, hueRotation = 0 }: ChordPale
               <button
                 className="chord-button"
                 onClick={() => handleChordClick(chord)}
-                title={`${getRomanNumeral(selectedKey, index)} - ${getChordDisplayName(chord)}`}
+                title={`${getRomanNumeral(selectedKey, index, minorScaleType)} - ${getChordDisplayName(chord)}`}
               >
-                <div className="chord-button-roman">{getRomanNumeral(selectedKey, index)}</div>
+                <div className="chord-button-roman">{getRomanNumeral(selectedKey, index, minorScaleType)}</div>
                 <div className="chord-button-name">{getChordDisplayName(chord)}</div>
               </button>
               <button

--- a/src/components/SettingsSidebar.css
+++ b/src/components/SettingsSidebar.css
@@ -174,6 +174,68 @@
   transform: translateY(1px);
 }
 
+/* Minor Scale Type Controls */
+.settings-sidebar .minor-scale-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+}
+
+.settings-sidebar .minor-scale-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1rem;
+  background-color: #2a2a2a;
+  border: 2px solid #555;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.settings-sidebar .minor-scale-option:hover {
+  border-color: #667eea;
+  background-color: #2f2f2f;
+}
+
+.settings-sidebar .minor-scale-option input[type="radio"] {
+  display: none;
+}
+
+.settings-sidebar .minor-scale-option input[type="radio"]:checked + .minor-scale-label {
+  color: #667eea;
+  font-weight: 600;
+}
+
+.settings-sidebar .minor-scale-option input[type="radio"]:checked ~ .minor-scale-detail {
+  color: #aaa;
+}
+
+.settings-sidebar .minor-scale-option input[type="radio"]:checked + .minor-scale-label::before {
+  content: '✓ ';
+  color: #667eea;
+  font-weight: bold;
+}
+
+.settings-sidebar .minor-scale-option:has(input:checked) {
+  border-color: #667eea;
+  background-color: rgba(102, 126, 234, 0.1);
+}
+
+.settings-sidebar .minor-scale-label {
+  font-size: 1rem;
+  color: #ccc;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.settings-sidebar .minor-scale-detail {
+  font-size: 0.85rem;
+  color: #888;
+  font-family: 'Courier New', monospace;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .settings-sidebar {

--- a/src/components/SettingsSidebar.tsx
+++ b/src/components/SettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import { Key } from '../types';
+import { Key, MinorScaleType } from '../types';
 import HueWheel from './HueWheel';
 import './SettingsSidebar.css';
 
@@ -8,6 +8,8 @@ interface SettingsSidebarProps {
   hueRotation: number;
   onHueRotationChange: (rotation: number) => void;
   selectedKey: Key;
+  minorScaleType: MinorScaleType;
+  onMinorScaleTypeChange: (scaleType: MinorScaleType) => void;
 }
 
 const SettingsSidebar = ({
@@ -15,7 +17,9 @@ const SettingsSidebar = ({
   onClose,
   hueRotation,
   onHueRotationChange,
-  selectedKey
+  selectedKey,
+  minorScaleType,
+  onMinorScaleTypeChange
 }: SettingsSidebarProps) => {
   return (
     <>
@@ -78,6 +82,50 @@ const SettingsSidebar = ({
             <p className="settings-description">
               Click on the color wheel or use the input to adjust the hue rotation.
               This affects all chord colors in the visualization.
+            </p>
+          </div>
+
+          {/* Minor Scale Type Control */}
+          <div className="settings-section">
+            <h3 className="settings-section-title">Minor Scale Type</h3>
+            <div className="minor-scale-options">
+              <label className="minor-scale-option">
+                <input
+                  type="radio"
+                  name="minor-scale-type"
+                  value="natural"
+                  checked={minorScaleType === 'natural'}
+                  onChange={() => onMinorScaleTypeChange('natural')}
+                />
+                <span className="minor-scale-label">Natural Minor</span>
+                <span className="minor-scale-detail">i, ii°, III, iv, v, VI, VII</span>
+              </label>
+              <label className="minor-scale-option">
+                <input
+                  type="radio"
+                  name="minor-scale-type"
+                  value="harmonic"
+                  checked={minorScaleType === 'harmonic'}
+                  onChange={() => onMinorScaleTypeChange('harmonic')}
+                />
+                <span className="minor-scale-label">Harmonic Minor</span>
+                <span className="minor-scale-detail">i, ii°, III+, iv, V, VI, vii°</span>
+              </label>
+              <label className="minor-scale-option">
+                <input
+                  type="radio"
+                  name="minor-scale-type"
+                  value="melodic"
+                  checked={minorScaleType === 'melodic'}
+                  onChange={() => onMinorScaleTypeChange('melodic')}
+                />
+                <span className="minor-scale-label">Melodic Minor</span>
+                <span className="minor-scale-detail">i, ii, III+, IV, V, vi°, vii°</span>
+              </label>
+            </div>
+            <p className="settings-description">
+              Select the minor scale type for generating diatonic chords in minor keys.
+              This only affects minor keys; major keys remain unchanged.
             </p>
           </div>
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ export type Tension = 9 | 11 | 13;
 
 export type Alteration = 'b9' | '#9' | '#11' | 'b13';
 
+export type MinorScaleType = 'natural' | 'harmonic' | 'melodic';
+
 export interface Chord {
   root: Note;
   quality: ChordQuality;

--- a/src/utils/diatonic.ts
+++ b/src/utils/diatonic.ts
@@ -1,4 +1,4 @@
-import { Key, Note, Chord } from '../types';
+import { Key, Note, Chord, MinorScaleType } from '../types';
 
 const NOTES: Note[] = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 
@@ -21,7 +21,7 @@ function getNote(root: Note, semitones: number): Note {
 /**
  * Generate diatonic chords for a given key
  */
-export function getDiatonicChords(key: Key): Chord[] {
+export function getDiatonicChords(key: Key, minorScaleType: MinorScaleType = 'melodic'): Chord[] {
   const { tonic, mode } = key;
 
   if (mode === 'major') {
@@ -36,31 +36,65 @@ export function getDiatonicChords(key: Key): Chord[] {
       { root: getNote(tonic, 11), quality: 'diminished', tensions: [], alterations: [], duration: 4 }, // vii°
     ];
   } else {
-    // Minor key: i, ii°, III, iv, v, VI, VII
-    return [
-      { root: getNote(tonic, 0), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // i
-      { root: getNote(tonic, 2), quality: 'diminished', tensions: [], alterations: [], duration: 4 },  // ii°
-      { root: getNote(tonic, 3), quality: 'major', tensions: [], alterations: [], duration: 4 },       // III
-      { root: getNote(tonic, 5), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // iv
-      { root: getNote(tonic, 7), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // v
-      { root: getNote(tonic, 8), quality: 'major', tensions: [], alterations: [], duration: 4 },       // VI
-      { root: getNote(tonic, 10), quality: 'major', tensions: [], alterations: [], duration: 4 },      // VII
-    ];
+    // Minor key - varies by scale type
+    if (minorScaleType === 'natural') {
+      // Natural minor: i, ii°, III, iv, v, VI, VII
+      return [
+        { root: getNote(tonic, 0), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // i
+        { root: getNote(tonic, 2), quality: 'diminished', tensions: [], alterations: [], duration: 4 },  // ii°
+        { root: getNote(tonic, 3), quality: 'major', tensions: [], alterations: [], duration: 4 },       // III
+        { root: getNote(tonic, 5), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // iv
+        { root: getNote(tonic, 7), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // v
+        { root: getNote(tonic, 8), quality: 'major', tensions: [], alterations: [], duration: 4 },       // VI
+        { root: getNote(tonic, 10), quality: 'major', tensions: [], alterations: [], duration: 4 },      // VII
+      ];
+    } else if (minorScaleType === 'harmonic') {
+      // Harmonic minor: i, ii°, III+, iv, V, VI, vii°
+      return [
+        { root: getNote(tonic, 0), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // i
+        { root: getNote(tonic, 2), quality: 'diminished', tensions: [], alterations: [], duration: 4 },  // ii°
+        { root: getNote(tonic, 3), quality: 'augmented', tensions: [], alterations: [], duration: 4 },   // III+
+        { root: getNote(tonic, 5), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // iv
+        { root: getNote(tonic, 7), quality: 'major', tensions: [], alterations: [], duration: 4 },       // V (raised 7th)
+        { root: getNote(tonic, 8), quality: 'major', tensions: [], alterations: [], duration: 4 },       // VI
+        { root: getNote(tonic, 11), quality: 'diminished', tensions: [], alterations: [], duration: 4 }, // vii°
+      ];
+    } else {
+      // Melodic minor (ascending): i, ii, III+, IV, V, vi°, vii°
+      return [
+        { root: getNote(tonic, 0), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // i
+        { root: getNote(tonic, 2), quality: 'minor', tensions: [], alterations: [], duration: 4 },       // ii (raised 6th)
+        { root: getNote(tonic, 3), quality: 'augmented', tensions: [], alterations: [], duration: 4 },   // III+
+        { root: getNote(tonic, 5), quality: 'major', tensions: [], alterations: [], duration: 4 },       // IV (raised 6th)
+        { root: getNote(tonic, 7), quality: 'major', tensions: [], alterations: [], duration: 4 },       // V (raised 7th)
+        { root: getNote(tonic, 9), quality: 'diminished', tensions: [], alterations: [], duration: 4 },  // vi° (raised 6th)
+        { root: getNote(tonic, 11), quality: 'diminished', tensions: [], alterations: [], duration: 4 }, // vii° (raised 7th)
+      ];
+    }
   }
 }
 
 /**
  * Get the roman numeral for a diatonic chord
  */
-export function getRomanNumeral(key: Key, chordIndex: number): string {
+export function getRomanNumeral(key: Key, chordIndex: number, minorScaleType: MinorScaleType = 'melodic'): string {
   const { mode } = key;
 
   if (mode === 'major') {
     const numerals = ['I', 'ii', 'iii', 'IV', 'V', 'vi', 'vii°'];
     return numerals[chordIndex] || '';
   } else {
-    const numerals = ['i', 'ii°', 'III', 'iv', 'v', 'VI', 'VII'];
-    return numerals[chordIndex] || '';
+    if (minorScaleType === 'natural') {
+      const numerals = ['i', 'ii°', 'III', 'iv', 'v', 'VI', 'VII'];
+      return numerals[chordIndex] || '';
+    } else if (minorScaleType === 'harmonic') {
+      const numerals = ['i', 'ii°', 'III+', 'iv', 'V', 'VI', 'vii°'];
+      return numerals[chordIndex] || '';
+    } else {
+      // Melodic minor
+      const numerals = ['i', 'ii', 'III+', 'IV', 'V', 'vi°', 'vii°'];
+      return numerals[chordIndex] || '';
+    }
   }
 }
 


### PR DESCRIPTION
## 概要

マイナーキーでナチュラルマイナー、ハーモニックマイナー、メロディックマイナーを選択できる機能を実装しました。

## 変更内容

### 機能追加
- 設定サイドバーに「Minor Scale Type」セクションを追加
- 3つのマイナースケールから選択可能:
  - **Natural Minor**: i, ii°, III, iv, v, VI, VII
  - **Harmonic Minor**: i, ii°, III+, iv, V, VI, vii° (導音を持つ)
  - **Melodic Minor**: i, ii, III+, IV, V, vi°, vii° (上昇形、6度と7度が上昇)
- デフォルト: Melodic Minor（issue仕様通り）
- LocalStorageで設定を永続化

### 技術的な変更

#### 型定義 (src/types/index.ts)
- `MinorScaleType`型を追加

#### utils/diatonic.ts
- `getDiatonicChords(key, minorScaleType)`にスケールタイプパラメータを追加
- `getRomanNumeral(key, chordIndex, minorScaleType)`にスケールタイプパラメータを追加
- 各スケールタイプに応じた正しいダイアトニックコードを生成

#### components/SettingsSidebar
- マイナースケールタイプ選択UIを追加
- ラジオボタンで3つのオプションを表示
- 各オプションにコード進行を表示

#### App.tsx
- `minorScaleType`状態を追加
- `handleMinorScaleTypeChange`ハンドラーでLocalStorageに保存
- BuildPhase、SettingsSidebarに`minorScaleType`を渡す

#### components/BuildPhase.tsx、ChordPalette.tsx
- `minorScaleType`プロップを受け取り、ダイアトニックコード生成に使用

## 動作確認

### メジャーキー
従来通りの動作（変更なし）

### マイナーキー（例: A minor）

**Natural Minor**:
- Am, Bdim, C, Dm, Em, F, G
- ローマ数字: i, ii°, III, iv, v, VI, VII

**Harmonic Minor**:
- Am, Bdim, Caug, Dm, E, F, G#dim
- ローマ数字: i, ii°, III+, iv, V, VI, vii°

**Melodic Minor**:
- Am, Bm, Caug, D, E, F#dim, G#dim
- ローマ数字: i, ii, III+, IV, V, vi°, vii°

## テスト

- ✅ ビルド成功
- ✅ TypeScript型チェック通過
- ✅ 開発サーバー起動確認
- ✅ 3つのスケールタイプでダイアトニックコードが正しく生成されることを確認

## スクリーンショット

設定サイドバーに新しい「Minor Scale Type」セクションが追加され、3つのオプションから選択できます。選択したスケールタイプに応じて、コードパレットのダイアトニックコードが変化します。

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)