### PR TITLE
複数セクション環境でのコード選択インデックスの不整合を修正

### DIFF
--- a/src/components/BuildPhase.tsx
+++ b/src/components/BuildPhase.tsx
@@ -18,7 +18,8 @@ interface BuildPhaseProps {
   onSelectChord: (index: number) => void;
   onUpdateChord: (index: number, chord: Chord) => void;
   currentIndex?: number;
-  selectedIndex?: number;
+  selectedIndex?: number; // Global index of selected chord
+  localSelectedIndex?: number; // Local index within current section
   timeSignature: number;
   onPlayingIndexChange: (index: number) => void;
   onPlaybackPositionChange: (position: number) => void;
@@ -48,6 +49,7 @@ const BuildPhase = ({
   onUpdateChord,
   currentIndex,
   selectedIndex,
+  localSelectedIndex,
   timeSignature,
   onPlayingIndexChange,
   onPlaybackPositionChange,
@@ -65,9 +67,9 @@ const BuildPhase = ({
   onSectionNameChange: _onSectionNameChange,
   onSectionKeyChange
 }: BuildPhaseProps) => {
-  // Get current chord for preview
-  const currentChord = selectedIndex !== undefined && selectedIndex >= 0
-    ? chords[selectedIndex]
+  // Get current chord for preview using local index
+  const currentChord = localSelectedIndex !== undefined && localSelectedIndex >= 0
+    ? chords[localSelectedIndex]
     : chords.length > 0
     ? chords[chords.length - 1]
     : undefined;
@@ -169,7 +171,7 @@ const BuildPhase = ({
       </div>
 
       {/* Editable chord info when a chord is selected */}
-      {selectedIndex !== undefined && selectedIndex >= 0 && currentChord && (
+      {selectedIndex !== undefined && selectedIndex >= 0 && localSelectedIndex !== undefined && currentChord && (
         <EditableChordInfo
           chord={currentChord}
           chordIndex={selectedIndex}


### PR DESCRIPTION
## 概要

複数セクションが存在する場合に、グローバルインデックス（全セクション通しのインデックス）とローカルインデックス（現在のセクション内のインデックス）が混在し、コード選択時に誤った情報が表示される問題を修正しました。

## 問題の詳細

### 再現手順
1. Section 1に `Em`, `F` を配置
2. Section 2に `Bdim`, `C` を配置
3. 各セクションでコードを選択

### 発生していた問題
- **Section 2選択中に`Em`をクリック** → `Bdim`の情報が表示される
- **Section 2選択中に`F`をクリック** → `C`の情報が表示される
- **`Bdim`/`C`を選択** → Color 2とEdit Chordが非表示になる

### 原因
グローバルインデックスとローカルインデックスの混在により、以下の問題が発生していました：
- `handleAddChord`: ローカルインデックスをグローバルとして設定
- `handleUpdateChord`: グローバルインデックスをローカルとして使用
- `BuildPhase`: グローバルインデックスで配列アクセス

## 修正内容

### 🔧 App.tsx

#### 1. `handleAddChord` - グローバルインデックス計算を修正
```typescript
// 現在のセクションまでの全コード数を加算してグローバル位置を算出
let globalIndex = 0;
for (const section of sections) {
  if (section.id === currentSectionId) {
    globalIndex += section.chords.length;
    break;
  }
  globalIndex += section.chords.length;
}
```

#### 2. `handleUpdateChord` - グローバル→ローカル変換を追加
```typescript
// グローバルインデックスから対象セクションとローカルインデックスを特定
let currentGlobalIndex = 0;
for (const section of sections) {
  if (globalIndex < currentGlobalIndex + section.chords.length) {
    targetSectionId = section.id;
    localIndex = globalIndex - currentGlobalIndex;
    break;
  }
  currentGlobalIndex += section.chords.length;
}
```

#### 3. `getLocalSelectedIndex` - 新規関数追加
グローバルインデックスを現在のセクションのローカルインデックスに変換する関数を追加。選択されたコードが現在のセクションに属さない場合は`undefined`を返します。

#### 4. `handleSelectChord` - セクション自動切り替え機能
```typescript
// 選択されたコードが属するセクションを自動検索して切り替え
for (const section of sections) {
  if (index < currentGlobalIndex + section.chords.length) {
    if (currentSectionId !== section.id) {
      setCurrentSectionId(section.id);
    }
    break;
  }
  currentGlobalIndex += section.chords.length;
}
```

### 🎨 BuildPhase.tsx

#### 1. `localSelectedIndex` prop追加
現在のセクション内でのローカルインデックスを新しいpropとして追加。

#### 2. `currentChord`取得ロジックを修正
```typescript
const currentChord = localSelectedIndex !== undefined && localSelectedIndex >= 0
  ? chords[localSelectedIndex]  // ローカルインデックスを使用
  : chords.length > 0
  ? chords[chords.length - 1]
  : undefined;
```

#### 3. `EditableChordInfo`表示条件を修正
```typescript
{selectedIndex !== undefined && selectedIndex >= 0 && 
 localSelectedIndex !== undefined && currentChord && (
  <EditableChordInfo ... />
)}
```

## 動作確認

✅ Section 1のコードを選択 → 正しい情報が表示  
✅ Section 2のコードを選択 → セクションが自動切り替わり、正しい情報が表示  
✅ 異なるセクション間でのコード選択がシームレスに動作  
✅ Visualization PreviewとEdit Chordが常に正しいコードの情報を表示  
✅ Color 1, Color 2が正しく表示される  
✅ Harmonic Function情報が正しく表示される

## テストケース

- [x] 単一セクションでのコード選択が正常に動作
- [x] 複数セクションでのコード選択が正常に動作
- [x] 異なるセクション間でのコード選択時に自動切り替え
- [x] コード追加時のインデックス計算が正確
- [x] コード更新時の対象コードが正確
- [x] コード削除時のインデックス調整が正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)